### PR TITLE
Fix build error when compile with "catkin build"

### DIFF
--- a/neuronbot2_bringup/CMakeLists.txt
+++ b/neuronbot2_bringup/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   tf
   dynamic_reconfigure
+  neuronbot2_msgs
 )
 ## Generate dynamic reconfigure parameters in the 'cfg' folder
 generate_dynamic_reconfigure_options(


### PR DESCRIPTION
Test on Ubuntu 20.04, Noetic
compile on current version will show error below:
    fatal error: neuronbot2_msgs/RawImu.h: No such file or directory 